### PR TITLE
Vertical Ship Limit

### DIFF
--- a/ship.py
+++ b/ship.py
@@ -155,6 +155,8 @@ class Ship(object):
         if self.y > HEIGHT:
             self.y = HEIGHT
             self.vely = 0
+        if self.y < (HEIGHT-175):
+            self.y = (HEIGHT-175)
         elif self.y < 0:
             self.y = 0
             self.vely = 0


### PR DESCRIPTION
Limits the players vertical ship limit, so the player can't collide with bubbles accidentally.